### PR TITLE
Add basic command line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ You should see a message warning that I am not a registered developer. Click **O
 You may need to confirm a second time:
 ![Security warning screenshot](images/security_warning.png)
 
+Command Line Interface
+----------------------
+
+If you're comfortable with command line interfaces then you can avoid overridding the macOS security checks described above while staying safe. Download the `export.py` file and use it like this: `./export.py output_directory`. If you're still (rightly) concerned about running random code downloaded from the Internet then take a look at `export.py`: it is less than 100 lines long and its only dependency is `pip3 install mutagen`.
 
 🎆 New features 🎆
 -----------------

--- a/export.py
+++ b/export.py
@@ -80,3 +80,9 @@ def export(episodes, output_dir, set_progress=None, emit_message=print):
         mp3.tags['album'] = podcast
         mp3.tags['title'] = title
         mp3.save()
+
+# This provides a very basic but functional Command Line Interface with
+# 'mutagen' as the only dependency
+if __name__ == '__main__':
+        output_dir = sys.argv[1]
+        export(get_downloaded_episodes(), output_dir)


### PR DESCRIPTION
Use an intermediate "output_dir" variable to make it very obvious what the argument should be when it's missing